### PR TITLE
Fix sawtooth wave frequency

### DIFF
--- a/pydalboard/signal/oscillators.py
+++ b/pydalboard/signal/oscillators.py
@@ -87,8 +87,8 @@ class Oscillator(SignalSource):
                 case Waveform.SQUARE:
                     table[i] = 1 if (i / self.table_size) % 1 < 0.5 else -1
                 case Waveform.SAWTOOTH:
-                    table[i] = 2 / math.pi * math.atan(math.tan(theta))
-        
+                    table[i] = 2 / math.pi * math.atan(math.tan(theta / 2))
+
         # Normalize the table
         table /= max(abs(table.min()), abs(table.max()))
 


### PR DESCRIPTION
The current computation method for the sawtooth wave is wrong, and doubles the frequency of the signal.